### PR TITLE
08: Widget Layout

### DIFF
--- a/apps/widget/app/page.tsx
+++ b/apps/widget/app/page.tsx
@@ -1,28 +1,16 @@
 "use client";
 
-import { useVapi } from "@/modules/widget/hooks/use-vapi";
-import { Button } from "@workspace/ui/components/button";
+import { WidgetView } from "@/modules/widget/ui/views/widget-view";
+import { use } from "react";
 
-export default function Page() {
-  const {
-    isSpeaking,
-    isConnecting,
-    isConnected,
-    transcript,
-    startCall,
-    endCall,
-  } = useVapi();
+interface Props {
+  searchParams: Promise<{
+    organizationId: string;
+  }>;
+}
 
-  return (
-    <div className="flex flex-col items-center justify-center min-h-svh max-w-md mx-auto w-full">
-      <Button onClick={() => startCall()}>Start Call</Button>
-      <Button onClick={() => endCall()} variant={"destructive"}>
-        End
-      </Button>
-      <p>isConnected: {`${isConnected}`}</p>
-      <p>isConnecting: {`${isConnecting}`}</p>
-      <p>isSpeaking: {`${isSpeaking}`}</p>
-      <pre>{JSON.stringify(transcript, null, 2)}</pre>
-    </div>
-  );
+export default function Page({ searchParams }: Props) {
+  const { organizationId } = use(searchParams);
+
+  return <WidgetView organizationId={organizationId} />;
 }

--- a/apps/widget/modules/widget/ui/components/widget-footer.tsx
+++ b/apps/widget/modules/widget/ui/components/widget-footer.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@workspace/ui/components/button";
+import { cn } from "@workspace/ui/lib/utils";
+import { HomeIcon, InboxIcon } from "lucide-react";
+
+export const WidgetFooter = () => {
+  const screen = "selection";
+
+  return (
+    <footer className="flex items-center justify-between border-t bg-background">
+      <Button
+        className="h-14 flex-1 rounded-none"
+        onClick={() => {}}
+        size="icon"
+        variant="ghost"
+      >
+        <HomeIcon
+          className={cn("size-5", screen === "selection" && "text-primary")}
+        />
+      </Button>
+      <Button
+        className="h-14 flex-1 rounded-none"
+        onClick={() => {}}
+        size="icon"
+        variant="ghost"
+      >
+        <InboxIcon
+          className={cn("size-5", screen === "inbox" && "text-primary")}
+        />
+      </Button>
+    </footer>
+  );
+};

--- a/apps/widget/modules/widget/ui/components/widget-header.tsx
+++ b/apps/widget/modules/widget/ui/components/widget-header.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@workspace/ui/lib/utils";
+
+export const WidgetHeader = ({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => {
+  return (
+    <header
+      className={cn(
+        "bg-gradient-to-b from-primary to-[#0b63f3] p-4 text-primary-foreground",
+        className
+      )}
+    >
+      {children}
+    </header>
+  );
+};

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { WidgetFooter } from "../components/widget-footer";
+import { WidgetHeader } from "../components/widget-header";
+
+interface Props {
+  organizationId: string;
+}
+
+export const WidgetView = ({ organizationId }: Props) => {
+  return (
+    <main className="flex h-full w-full flex-col min-h-screen min-w-screen overflow-hidden rounded-xl border bg-muted">
+      <WidgetHeader>
+        <div className="flex flex-col justify-between gap-y-2 px-2 py-6">
+          <p className="text-3xl">Hi there! 👋</p>
+          <p className="text-lg">How can we help you today?</p>
+        </div>
+      </WidgetHeader>
+      <div className="flex flex-1">Widget View: {organizationId}</div>
+      <WidgetFooter />
+    </main>
+  );
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduced the initial widget layout with a header, footer, and a centralized WidgetView. The page now reads organizationId from search params and passes it to the view, replacing the inline call controls.

- **New Features**
  - WidgetHeader with gradient and greeting.
  - WidgetFooter with Home and Inbox icons and active state styling.
  - WidgetView composing header/body/footer and displaying organizationId.

- **Migration**
  - Load the widget with ?organizationId=<id> in the URL so the view renders correctly.

<!-- End of auto-generated description by cubic. -->

